### PR TITLE
Fix maven usage errors in testcases example project.

### DIFF
--- a/org.eclipse.m2e.wtp.tests/projects/MECLIPSEWTP-220/pom.xml
+++ b/org.eclipse.m2e.wtp.tests/projects/MECLIPSEWTP-220/pom.xml
@@ -18,6 +18,7 @@
 						<jarModule>
 							<groupId>junit</groupId>
 							<artifactId>junit</artifactId>
+							<includeInApplicationXml>true</includeInApplicationXml>
 						</jarModule>
 					</modules>
 				</configuration>

--- a/org.eclipse.m2e.wtp.tests/projects/MNGECLIPSE-688/ear21-1/pom.xml
+++ b/org.eclipse.m2e.wtp.tests/projects/MNGECLIPSE-688/ear21-1/pom.xml
@@ -11,6 +11,13 @@
   			<artifactId>maven-ear-plugin</artifactId>
   			<configuration>
   				<earSourceDirectory>CustomEarSourceDirectory</earSourceDirectory>
+				<modules><!-- an EAR application.xml must have at least 1 module to be well formed DTD/XSD -->
+					<jarModule>
+						<groupId>junit</groupId>
+						<artifactId>junit</artifactId>
+						<includeInApplicationXml>true</includeInApplicationXml>
+					</jarModule>
+				</modules>
   			</configuration>
   		</plugin>
   	</plugins>

--- a/org.eclipse.m2e.wtp.tests/projects/manifests/MECLIPSEWTP-66/war/pom.xml
+++ b/org.eclipse.m2e.wtp.tests/projects/manifests/MECLIPSEWTP-66/war/pom.xml
@@ -31,4 +31,15 @@
 			<version>0.0.1-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-war-plugin</artifactId>
+				<configuration>
+				    <failOnMissingWebXml>false</failOnMissingWebXml>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/org.eclipse.m2e.wtp.tests/projects/overlays/war-overlay1/pom.xml
+++ b/org.eclipse.m2e.wtp.tests/projects/overlays/war-overlay1/pom.xml
@@ -13,4 +13,15 @@
 			<type>war</type>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-war-plugin</artifactId>
+				<configuration>
+				    <failOnMissingWebXml>false</failOnMissingWebXml>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
Some test cases were using Maven in a way that would result in a maven build
failure if the test-case project was built from the command line.

Some test cases were using Maven in a way that would result in invalid EAR
application.xml files to be produced.  It is a requirement for at least one
<modules> element to exist.

These changes appear to correct the following test cases:
    org.eclipse.m2e.wtp.tests.OverlayTest
    org.eclipse.m2e.wtp.tests.conversion.EjbProjectConversionTest
